### PR TITLE
build: fix mechanism for additional dependencies

### DIFF
--- a/bin/templates/project/cordova/lib/build.js
+++ b/bin/templates/project/cordova/lib/build.js
@@ -26,6 +26,7 @@ var Q = require('q');
 var path = require('path');
 var shell = require('shelljs');
 
+var ConfigParser = require('./config_parser');
 var Constants = require('./constants');
 var Utils = require('./utils');
 var Manifest = require('./manifest');
@@ -233,19 +234,13 @@ function fillTemplate(source, dest, obj) {
 }
 
 function additionalBuildDependencies(ubuntuDir) {
-    var files = [];
-    try {
-        files = fs.readdirSync(path.join(ubuntuDir, 'configs')).filter(function(s) {
-            return s[0] != '.';
-        });
-    } catch (e) {}
+    var config = new ConfigParser(path.join(ubuntuDir, 'config.xml'));
 
     var pkgConfig = [];
-    for (var i = 0; i < files.length; i++) {
-        var config = JSON.parse(fs.readFileSync(path.join(ubuntuDir, 'configs', files[i])));
-        if (config.pkgConfig)
-            pkgConfig = pkgConfig.concat(config.pkgConfig);
-    }
+    config.etree.getroot().findall('./feature/deps/pkgConfig').forEach(function (element) {
+        var list = JSON.parse(element.text);
+        pkgConfig = pkgConfig.concat(list);
+    });
 
     return pkgConfig;
 }
@@ -375,17 +370,13 @@ function checkChrootEnv(ubuntuDir, architecture, framework) {
 }
 
 function additionalDependencies(ubuntuDir) {
-    var files = [];
-    try {
-        files = fs.readdirSync(path.join(ubuntuDir, 'configs')).filter(function(s) {
-            return s[0] != '.';
-        });
-    } catch (e) {}
+    var config = new ConfigParser(path.join(ubuntuDir, 'config.xml'));
+
     var deb = [];
-    for (var i = 0; i < files.length; i++) {
-        var config = JSON.parse(fs.readFileSync(path.join(ubuntuDir, 'configs', files[i])));
-        if (config.deb)
-            deb = deb.concat(config.deb);
-    }
+    config.etree.getroot().findall('./feature/deps/deb').forEach(function (element) {
+        var list = JSON.parse(element.text);
+        deb = deb.concat(list);
+    });
+
     return deb;
 }


### PR DESCRIPTION
Instead of expecting plugins to store their configuration files in
a "configs/" directory, read the dependencies from the `config.xml` file.
The reason why the old method does not work is that the `<resource-file>`
element of the `plugin.xml` file doesn't support a "target-dir" attribute.

By using the `<config-file>` element, instead, we don't need to do any
changes to cordova lib, and all the plugin configuration can now be
stored in the `plugin.xml` file.

Example:

``` xml
<config-file target="config.xml" parent="/*">
  <feature name="FacebookConnect">
    <param policy_group="accounts" policy_version="1" />
    <param hook="account-application" value="qml/app.application" />
    <param hook="account-service" value="qml/app.service" />
    <deps>
      <pkgConfig>["signond", "libsignon-qt5"]</pkgConfig>
      <deb>["signond-dev:ARCH", "libsignon-qt5-dev:ARCH"]</deb>
    </deps>
  </feature>
</config-file>
```
