### PR TITLE
Cb 9806 - Add icon to project defaults

### DIFF
--- a/bin/templates/project/cordova/defaults.xml
+++ b/bin/templates/project/cordova/defaults.xml
@@ -19,6 +19,9 @@
 -->
 <widget id="io.cordova.hellocordova" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
 
+      <!-- icon requirement for Ubuntu click packages -->
+      <icon src="www/img/icon.png" />
+
       <preference name="loglevel" value="DEBUG" />
       <!--
         <preference name="splashscreen" value="resourceName" />
@@ -27,7 +30,6 @@
         <preference name="InAppBrowserStorageEnabled" value="true" />
         <preference name="disallowOverscroll" value="true" />
       -->
-      <!-- <icon src="icon.png" /> -->
 
 </widget>
 

--- a/bin/templates/project/cordova/defaults.xml
+++ b/bin/templates/project/cordova/defaults.xml
@@ -20,7 +20,7 @@
 <widget id="io.cordova.hellocordova" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
 
       <!-- icon requirement for Ubuntu click packages -->
-      <icon src="www/img/icon.png" />
+      <icon src="www/img/logo.png" />
 
       <preference name="loglevel" value="DEBUG" />
       <!--


### PR DESCRIPTION
An icon is required for packaging an Ubuntu application. The project defaults should declare an icon in config.xml to avoid an unnecessary error.

This pull request works in conjunction with a cordova-lib pull request that applies the value to a config.xml with a missing icon parameter.
